### PR TITLE
Fix undefined isChatActive in AppShell

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -109,6 +109,9 @@ export const AppShell: React.FC<AppShellProps> = ({ children }) => {
 
   const navItems = getNavItems();
 
+  // Check if current route is a chat route
+  const isChatActive = location.pathname.includes('/chat');
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 via-primary-50/30 to-gray-100 dark:from-dark-950 dark:via-dark-900 dark:to-dark-800 transition-all duration-300">
       {/* Sidebar */}


### PR DESCRIPTION
Define `isChatActive` variable in `AppShell` to fix `ReferenceError: isChatActive is not defined`.

The `isChatActive` variable was referenced in the `AppShell` component for conditional styling of navigation items related to chat routes (e.g., `/staff/chat`, `/admin/chat`) but was not defined. This PR defines `isChatActive` by checking if the current `location.pathname` includes '/chat', resolving the runtime error.

---
<a href="https://cursor.com/background-agent?bcId=bc-13691581-ad32-4ed2-93ff-76b17fcaa25b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13691581-ad32-4ed2-93ff-76b17fcaa25b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

