### PR TITLE
Handle chat context rate limiting

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Support Desk - Customer Support System</title>
-    <script type="module" crossorigin src="/assets/index-BZapnJ6s.js"></script>
+    <script type="module" crossorigin src="/assets/index-Bp0jDDGJ.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D3yqBMNL.css">
   </head>
   <body>


### PR DESCRIPTION
Implement robust 429 rate limit handling in the frontend and make backend rate limits configurable to prevent "Too many requests" errors.

The frontend was crashing when the backend returned a 429 "Too many requests" error. This PR addresses the issue by making the backend rate limits configurable (with increased defaults and skips for safe routes) and by adding exponential backoff, `Retry-After` header respect, and a single user notification to the frontend's API call logic. Periodic refreshes are also paused during rate-limiting to avoid spamming.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa7e3af7-0a8e-44b2-b5f2-40083fb792d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa7e3af7-0a8e-44b2-b5f2-40083fb792d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

