### PR TITLE
Investigate chat team page loading issue

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Support Desk - Customer Support System</title>
-    <script type="module" crossorigin src="/assets/index-BZapnJ6s.js"></script>
+    <script type="module" crossorigin src="/assets/index-NhKVnXP9.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D3yqBMNL.css">
   </head>
   <body>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -26,8 +26,8 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   const allowedPaths = [
     '/my/tickets', '/my/tickets/new', '/my/tickets/', '/my/marketplace', '/my/notifications',
     '/staff/tickets', '/staff/tickets/', '/staff/dashboard', '/staff/ai-support', 
-    '/staff/marketplace', '/staff/leaderboard', '/staff/notifications',
-    '/admin/categories', '/admin/staff', '/admin/slack', '/admin/ai-support',
+    '/staff/marketplace', '/staff/leaderboard', '/staff/notifications', '/staff/chat',
+    '/admin/categories', '/admin/staff', '/admin/slack', '/admin/ai-support', '/admin/chat',
     '/admin/marketplace', '/admin/leaderboard', '/admin/notifications'
   ];
   

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -47,14 +47,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = React.memo(({ children 
       });
 
       if (!response.ok) {
-        try {
-          const error = await response.json();
-          throw new Error(error.error || 'Token refresh failed');
-        } catch (jsonError) {
-          // If response is not valid JSON, try to get text
-          const text = await response.text();
-          throw new Error(text || `Token refresh failed with status ${response.status}`);
-        }
+        const raw = await response.text();
+        let parsed: any;
+        try { parsed = JSON.parse(raw); } catch {}
+        const message = (parsed && (parsed.error || parsed.message)) || raw || `Token refresh failed with status ${response.status}`;
+        throw new Error(message);
       }
 
       const { accessToken, refreshToken: newRefreshToken } = await response.json();

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -48,14 +48,11 @@ class ApiClient {
     });
 
     if (!response.ok) {
-      try {
-        const error = await response.json();
-        throw new Error(error.error || 'Login failed');
-      } catch (jsonError) {
-        // If response is not valid JSON, try to get text
-        const text = await response.text();
-        throw new Error(text || `Login failed with status ${response.status}`);
-      }
+      const raw = await response.text();
+      let parsed: any;
+      try { parsed = JSON.parse(raw); } catch {}
+      const message = (parsed && (parsed.error || parsed.message)) || raw || `Login failed with status ${response.status}`;
+      throw new Error(message);
     }
 
     return response.json();
@@ -69,14 +66,11 @@ class ApiClient {
     });
 
     if (!response.ok) {
-      try {
-        const error = await response.json();
-        throw new Error(error.error || 'Signup failed');
-      } catch (jsonError) {
-        // If response is not valid JSON, try to get text
-        const text = await response.text();
-        throw new Error(text || `Signup failed with status ${response.status}`);
-      }
+      const raw = await response.text();
+      let parsed: any;
+      try { parsed = JSON.parse(raw); } catch {}
+      const message = (parsed && (parsed.error || parsed.message)) || raw || `Signup failed with status ${response.status}`;
+      throw new Error(message);
     }
 
     return response.json();
@@ -90,14 +84,11 @@ class ApiClient {
     });
 
     if (!response.ok) {
-      try {
-        const error = await response.json();
-        throw new Error(error.error || 'Token refresh failed');
-      } catch (jsonError) {
-        // If response is not valid JSON, try to get text
-        const text = await response.text();
-        throw new Error(text || `Token refresh failed with status ${response.status}`);
-      }
+      const raw = await response.text();
+      let parsed: any;
+      try { parsed = JSON.parse(raw); } catch {}
+      const message = (parsed && (parsed.error || parsed.message)) || raw || `Token refresh failed with status ${response.status}`;
+      throw new Error(message);
     }
 
     return response.json();


### PR DESCRIPTION
Enable chat pages by whitelisting routes and fix 'body stream already read' error in API response handling.

The "body stream already read" error occurred because the `fetch` API response body was being consumed twice in the error handling logic (first attempting `response.json()`, then `response.text()` if `json()` failed). This PR modifies the error handling to read the response body once as text and then conditionally parse it as JSON, preventing the stream from being read multiple times.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec6de4b7-48d9-4927-8b14-9b88640d1879">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec6de4b7-48d9-4927-8b14-9b88640d1879">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

