### PR TITLE
Fix login API response body read error

### DIFF
--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -47,18 +47,35 @@ class ApiClient {
       body: JSON.stringify({ email, password }),
     });
 
+    // Read the response body only once
+    const responseText = await response.text();
+
     if (!response.ok) {
-      try {
-        const error = await response.json();
-        throw new Error(error.error || 'Login failed');
-      } catch (jsonError) {
-        // If response is not valid JSON, try to get text
-        const text = await response.text();
-        throw new Error(text || `Login failed with status ${response.status}`);
+      // Try to parse as JSON for error message
+      let errorMessage = `Login failed with status ${response.status}`;
+      if (responseText) {
+        try {
+          const errorData = JSON.parse(responseText);
+          errorMessage = errorData.error || errorData.message || errorMessage;
+        } catch {
+          // If not valid JSON, use the raw text
+          errorMessage = responseText;
+        }
       }
+      throw new Error(errorMessage);
     }
 
-    return response.json();
+    // Handle successful response
+    if (!responseText) {
+      // Handle empty 204 responses or similar
+      return null;
+    }
+
+    try {
+      return JSON.parse(responseText);
+    } catch {
+      throw new Error('Invalid response format from server');
+    }
   }
 
   async signup(data: SignupRequest): Promise<LoginResponse> {
@@ -68,18 +85,35 @@ class ApiClient {
       body: JSON.stringify(data),
     });
 
+    // Read the response body only once
+    const responseText = await response.text();
+
     if (!response.ok) {
-      try {
-        const error = await response.json();
-        throw new Error(error.error || 'Signup failed');
-      } catch (jsonError) {
-        // If response is not valid JSON, try to get text
-        const text = await response.text();
-        throw new Error(text || `Signup failed with status ${response.status}`);
+      // Try to parse as JSON for error message
+      let errorMessage = `Signup failed with status ${response.status}`;
+      if (responseText) {
+        try {
+          const errorData = JSON.parse(responseText);
+          errorMessage = errorData.error || errorData.message || errorMessage;
+        } catch {
+          // If not valid JSON, use the raw text
+          errorMessage = responseText;
+        }
       }
+      throw new Error(errorMessage);
     }
 
-    return response.json();
+    // Handle successful response
+    if (!responseText) {
+      // Handle empty 204 responses or similar
+      return null;
+    }
+
+    try {
+      return JSON.parse(responseText);
+    } catch {
+      throw new Error('Invalid response format from server');
+    }
   }
 
   async refreshToken(refreshToken: string): Promise<{ accessToken: string; refreshToken: string }> {
@@ -89,18 +123,35 @@ class ApiClient {
       body: JSON.stringify({ refreshToken }),
     });
 
+    // Read the response body only once
+    const responseText = await response.text();
+
     if (!response.ok) {
-      try {
-        const error = await response.json();
-        throw new Error(error.error || 'Token refresh failed');
-      } catch (jsonError) {
-        // If response is not valid JSON, try to get text
-        const text = await response.text();
-        throw new Error(text || `Token refresh failed with status ${response.status}`);
+      // Try to parse as JSON for error message
+      let errorMessage = `Token refresh failed with status ${response.status}`;
+      if (responseText) {
+        try {
+          const errorData = JSON.parse(responseText);
+          errorMessage = errorData.error || errorData.message || errorMessage;
+        } catch {
+          // If not valid JSON, use the raw text
+          errorMessage = responseText;
+        }
       }
+      throw new Error(errorMessage);
     }
 
-    return response.json();
+    // Handle successful response
+    if (!responseText) {
+      // Handle empty 204 responses or similar
+      return null;
+    }
+
+    try {
+      return JSON.parse(responseText);
+    } catch {
+      throw new Error('Invalid response format from server');
+    }
   }
 
   async me(token: string): Promise<{ user: User }> {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -45,6 +45,16 @@ export const LoginPage: React.FC = () => {
       });
 
       console.log('Login successful:', result);
+      
+      // Handle case where result might be null (empty response)
+      if (!result) {
+        throw new Error('Empty response from server');
+      }
+
+      if (!result.accessToken || !result.user) {
+        throw new Error('Invalid login response: missing required data');
+      }
+
       login(result.accessToken, result.refreshToken, result.user);
       
       addToast(`Welcome back, ${result.user.name}! 🎉`, 'success');


### PR DESCRIPTION
Fixes login, signup, and token refresh API flows to prevent "body stream already read" errors.

The root cause was multiple attempts to read the response body (e.g., `response.json()` and `response.text()`) within the same request handling, leading to `TypeError: Failed to execute 'text' on 'Response': body stream already read`. This PR ensures the response body is read only once, handles empty responses, and provides consistent error messaging across `ApiClient` methods, `AuthContext`, and login pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-9fb6f09a-b514-4e00-a3c7-fb8db965779c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9fb6f09a-b514-4e00-a3c7-fb8db965779c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

