### PR TITLE
Fix login response body stream error

### DIFF
--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -48,13 +48,15 @@ class ApiClient {
     });
 
     if (!response.ok) {
+      // Read the response body once and then decide how to parse it
+      const responseText = await response.text();
+      
       try {
-        const error = await response.json();
+        const error = JSON.parse(responseText);
         throw new Error(error.error || 'Login failed');
       } catch (jsonError) {
-        // If response is not valid JSON, try to get text
-        const text = await response.text();
-        throw new Error(text || `Login failed with status ${response.status}`);
+        // If response is not valid JSON, use the text directly
+        throw new Error(responseText || `Login failed with status ${response.status}`);
       }
     }
 
@@ -69,13 +71,15 @@ class ApiClient {
     });
 
     if (!response.ok) {
+      // Read the response body once and then decide how to parse it
+      const responseText = await response.text();
+      
       try {
-        const error = await response.json();
+        const error = JSON.parse(responseText);
         throw new Error(error.error || 'Signup failed');
       } catch (jsonError) {
-        // If response is not valid JSON, try to get text
-        const text = await response.text();
-        throw new Error(text || `Signup failed with status ${response.status}`);
+        // If response is not valid JSON, use the text directly
+        throw new Error(responseText || `Signup failed with status ${response.status}`);
       }
     }
 
@@ -90,13 +94,15 @@ class ApiClient {
     });
 
     if (!response.ok) {
+      // Read the response body once and then decide how to parse it
+      const responseText = await response.text();
+      
       try {
-        const error = await response.json();
+        const error = JSON.parse(responseText);
         throw new Error(error.error || 'Token refresh failed');
       } catch (jsonError) {
-        // If response is not valid JSON, try to get text
-        const text = await response.text();
-        throw new Error(text || `Token refresh failed with status ${response.status}`);
+        // If response is not valid JSON, use the text directly
+        throw new Error(responseText || `Token refresh failed with status ${response.status}`);
       }
     }
 


### PR DESCRIPTION
Fix "body stream already read" error by reading response body once in API error handling.

The previous implementation attempted to read the response body as JSON, and if that failed, it would try to read it again as plain text. This caused a `TypeError` because a `Response` body stream can only be read once. The fix reads the body once as text, then attempts to parse it as JSON, falling back to the raw text if JSON parsing fails. This prevents the stream from being consumed multiple times.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a0946d3-04a5-4330-999d-1b38a11811db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a0946d3-04a5-4330-999d-1b38a11811db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

