### PR TITLE
Fix router updates in StaffTicketDetail

### DIFF
--- a/src/pages/customer/TicketDetail.tsx
+++ b/src/pages/customer/TicketDetail.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSecureParams } from '../../hooks/useSecureParams';
 import { ArrowLeft, Clock } from 'lucide-react';
@@ -17,9 +17,15 @@ export const TicketDetail: React.FC = () => {
   const { user } = useAuth();
   const { addToast } = useToast();
 
-  // Security: Validate ticket ID
+  // Security: Validate ticket ID using useEffect to avoid render warnings
+  useEffect(() => {
+    if (!id) {
+      navigate('/my/tickets', { replace: true });
+    }
+  }, [id, navigate]);
+
+  // Early return if no ID (component will be redirected via useEffect)
   if (!id) {
-    navigate('/my/tickets', { replace: true });
     return null;
   }
 

--- a/src/pages/staff/StaffTicketDetail.tsx
+++ b/src/pages/staff/StaffTicketDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSecureParams } from '../../hooks/useSecureParams';
 import { ArrowLeft, UserPlus, Clock } from 'lucide-react';
@@ -22,9 +22,15 @@ export const StaffTicketDetail: React.FC = () => {
   const { addToast } = useToast();
   const [isAssignDrawerOpen, setIsAssignDrawerOpen] = useState(false);
 
-  // Security: Validate ticket ID
+  // Security: Validate ticket ID using useEffect to avoid render warnings
+  useEffect(() => {
+    if (!id) {
+      navigate('/staff/tickets', { replace: true });
+    }
+  }, [id, navigate]);
+
+  // Early return if no ID (component will be redirected via useEffect)
   if (!id) {
-    navigate('/staff/tickets', { replace: true });
     return null;
   }
 
@@ -38,6 +44,14 @@ export const StaffTicketDetail: React.FC = () => {
 
   const ticket = ticketData?.ticket;
   const messages = ticket?.messages || [];
+
+  // Handle case where ticket doesn't exist after loading
+  useEffect(() => {
+    if (!isLoading && !error && !ticket) {
+      // Ticket not found, redirect will be handled by the render return
+      console.log('Ticket not found after loading completed');
+    }
+  }, [isLoading, error, ticket]);
 
   const handleReply = async (data: { message: string }) => {
     if (!user || !ticket) return;


### PR DESCRIPTION
Move `navigate()` calls to `useEffect` in ticket detail components to prevent React warnings about updating the router during render.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee7ddcdb-8f54-4778-a43f-18838ae81f8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee7ddcdb-8f54-4778-a43f-18838ae81f8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

