### PR TITLE
Fix router update in staff ticket detail

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Support Desk - Customer Support System</title>
-    <script type="module" crossorigin src="/assets/index-BZapnJ6s.js"></script>
+    <script type="module" crossorigin src="/assets/index-BWctmVQm.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D3yqBMNL.css">
   </head>
   <body>

--- a/src/pages/customer/TicketDetail.tsx
+++ b/src/pages/customer/TicketDetail.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSecureParams } from '../../hooks/useSecureParams';
 import { ArrowLeft, Clock } from 'lucide-react';
@@ -17,9 +17,15 @@ export const TicketDetail: React.FC = () => {
   const { user } = useAuth();
   const { addToast } = useToast();
 
-  // Security: Validate ticket ID
+  // Security: Validate ticket ID - moved to useEffect to prevent render-time navigation
+  useEffect(() => {
+    if (!id) {
+      navigate('/my/tickets', { replace: true });
+    }
+  }, [id, navigate]);
+
+  // Early return if no ID - but don't navigate here
   if (!id) {
-    navigate('/my/tickets', { replace: true });
     return null;
   }
 

--- a/src/pages/staff/StaffTicketDetail.tsx
+++ b/src/pages/staff/StaffTicketDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSecureParams } from '../../hooks/useSecureParams';
 import { ArrowLeft, UserPlus, Clock } from 'lucide-react';
@@ -22,9 +22,15 @@ export const StaffTicketDetail: React.FC = () => {
   const { addToast } = useToast();
   const [isAssignDrawerOpen, setIsAssignDrawerOpen] = useState(false);
 
-  // Security: Validate ticket ID
+  // Security: Validate ticket ID - moved to useEffect to prevent render-time navigation
+  useEffect(() => {
+    if (!id) {
+      navigate('/staff/tickets', { replace: true });
+    }
+  }, [id, navigate]);
+
+  // Early return if no ID - but don't navigate here
   if (!id) {
-    navigate('/staff/tickets', { replace: true });
     return null;
   }
 


### PR DESCRIPTION
Move `navigate()` calls into `useEffect` hooks in `StaffTicketDetail.tsx` and `TicketDetail.tsx` to resolve React router warnings.

The previous implementation called `navigate()` directly in the component's render body, which caused React to attempt updating the `BrowserRouter` during the rendering of another component. Moving these calls into `useEffect` ensures that navigation, a side effect, occurs after the render phase, adhering to React's lifecycle best practices.

---
<a href="https://cursor.com/background-agent?bcId=bc-eebbd098-a9e2-4885-b215-481cff74f4ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eebbd098-a9e2-4885-b215-481cff74f4ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

