### PR TITLE
Fix ticket ID validation and graceful error handling

### DIFF
--- a/src/hooks/useSecureParams.ts
+++ b/src/hooks/useSecureParams.ts
@@ -1,9 +1,9 @@
-import { useParams, useSearchParams } from 'react-router-dom';
-import { useMemo } from 'react';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import { useMemo, useEffect } from 'react';
 
 // Whitelist of allowed parameter names and their validation patterns
 const ALLOWED_PARAMS = {
-  id: /^[0-9]+$/,           // Only numeric IDs
+  id: /^[A-Za-z0-9_-]+$/,      // Allow alphanumeric IDs with hyphens and underscores (e.g., T001, T-001_A)
   status: /^(open|in_progress|resolved|closed)$/,
   priority: /^(low|medium|high|urgent)$/,
   category: /^[a-zA-Z0-9_-]+$/,
@@ -26,6 +26,7 @@ interface SecureSearchParams {
 
 export const useSecureParams = (): SecureParams => {
   const params = useParams();
+  const navigate = useNavigate();
   
   return useMemo(() => {
     const secureParams: SecureParams = {};
@@ -37,6 +38,8 @@ export const useSecureParams = (): SecureParams => {
           secureParams[key] = value;
         } else {
           console.warn(`Invalid parameter value for ${key}: ${value}`);
+          // For critical parameters like 'id', we might want to handle this more gracefully
+          // but we'll let the consuming component handle the redirect logic
         }
       } else if (value) {
         console.warn(`Unauthorized parameter: ${key}`);
@@ -90,11 +93,11 @@ export const sanitizeNavigationPath = (path: string): string => {
   const allowedPatterns = [
     /^\/login$/,
     /^\/signup$/,
-    /^\/my\/tickets(\/[0-9]+)?$/,
+    /^\/my\/tickets(\/[A-Za-z0-9_-]+)?$/,
     /^\/my\/tickets\/new$/,
     /^\/my\/marketplace$/,
     /^\/my\/notifications$/,
-    /^\/staff\/tickets(\/[0-9]+)?$/,
+    /^\/staff\/tickets(\/[A-Za-z0-9_-]+)?$/,
     /^\/staff\/dashboard$/,
     /^\/staff\/ai-support$/,
     /^\/staff\/marketplace$/,

--- a/src/pages/staff/StaffTicketDetail.tsx
+++ b/src/pages/staff/StaffTicketDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useSecureParams } from '../../hooks/useSecureParams';
+import { useSecureParams, validateParamValue } from '../../hooks/useSecureParams';
 import { ArrowLeft, UserPlus, Clock } from 'lucide-react';
 import { useTicket, useCreateMessage, useUpdateTicket, useCategories, useUsers } from '../../hooks/useApi';
 import { useAuth } from '../../context/AuthContext';
@@ -22,14 +22,24 @@ export const StaffTicketDetail: React.FC = () => {
   const { addToast } = useToast();
   const [isAssignDrawerOpen, setIsAssignDrawerOpen] = useState(false);
 
-  // Security: Validate ticket ID using useEffect to avoid render warnings
+  // Enhanced security validation for ticket ID
   useEffect(() => {
     if (!id) {
+      // No ID provided or ID failed validation in useSecureParams
+      console.warn('Invalid or missing ticket ID, redirecting to tickets list');
       navigate('/staff/tickets', { replace: true });
+      return;
+    }
+    
+    // Additional client-side validation as a fallback
+    if (!validateParamValue('id', id)) {
+      console.warn(`Ticket ID format validation failed for: ${id}`);
+      navigate('/staff/tickets', { replace: true });
+      return;
     }
   }, [id, navigate]);
 
-  // Early return if no ID (component will be redirected via useEffect)
+  // Early return if no valid ID (component will be redirected via useEffect)
   if (!id) {
     return null;
   }


### PR DESCRIPTION
Allow alphanumeric ticket IDs in `useSecureParams` and `StaffTicketDetail` to fix invalid parameter errors and enable graceful navigation.

The previous validation regex for the `id` parameter in `useSecureParams.ts` only accepted numeric values, causing ticket IDs like "T001" to be considered invalid. This PR updates the regex to support alphanumeric IDs with hyphens and underscores, and enhances `StaffTicketDetail.tsx` with client-side validation and a graceful redirect to prevent crashes when an invalid ID is encountered.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8e63abe-e77f-465b-9545-09dab74ab499">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8e63abe-e77f-465b-9545-09dab74ab499">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

